### PR TITLE
Update the runtime version from 23.08 to 25.08, and more

### DIFF
--- a/io.defn.Franz.desktop
+++ b/io.defn.Franz.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Exec=Franz
+Name=Franz
+Icon=io.defn.Franz
+Version=1.5
+Comment=Desktop client for Apache Kafka
+Categories=Development
+Terminal=false

--- a/io.defn.Franz.metainfo.xml
+++ b/io.defn.Franz.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.defn.Franz</id>
+  <name>Franz</name>
+  <summary>A desktop client for Apache Kafka</summary>
+  <metadata_license>CC-BY-SA</metadata_license>
+  <project_license>LicenseRef-proprietary=https://franz.defn.io/license.html</project_license>
+  <developer_name>CLEARTYPE SRL</developer_name>
+
+  <url type="homepage">https://franz.defn.io</url>
+  <url type="help">https://franz.defn.io/manual</url>
+
+  <description>
+    <p>Franz is a desktop client for Apache Kafka and other Apache Kafka-compatible brokers like RedPanda.
+      Use it to inspect and modify the state of your cluster, search for your data, modify consumer groups and more.</p>
+    <p>Franz is available for a free 30-day trial. Individual and company licenses can be purchased at https://franz.defn.io/buy.html.</p>
+  </description>
+
+  <launchable type="desktop-id">io.defn.Franz.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://franz.defn.io/assets/01-welcome-window.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://franz.defn.io/assets/02-topic-records-table.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://franz.defn.io/assets/03-consumer-group.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://franz.defn.io/assets/04-aws-msk-iam.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://franz.defn.io/assets/05-lua-scripting.png</image>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="1.9" date="2026-06-01" />
+    <release version="1.6.1" date="2024-01-11" />
+    <release version="1.6" date="2024-01-06" />
+    <release version="1.5" date="2023-12-04" />
+    <release version="1.4" date="2023-11-12" />
+    <release version="1.3" date="2023-10-30" />
+    <release version="1.2" date="2023-10-15" />
+  </releases>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+</component>

--- a/io.defn.Franz.yml
+++ b/io.defn.Franz.yml
@@ -1,8 +1,9 @@
 app-id: io.defn.Franz
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: Franz
+rename-icon: icon
 finish-args:
   - --share=ipc
   - --share=network
@@ -11,16 +12,20 @@ finish-args:
 modules:
   - name: Franz
     buildsystem: simple
+    build-options:
+      no-debuginfo: true
     build-commands:
       - cp -r bin /app/bin
       - cp -r lib /app/lib
-      - install -D icon.svg /app/share/icons/hicolor/scalable/apps/io.defn.Franz.svg
-      - install -D io.defn.Franz.desktop /app/share/applications/io.defn.Franz.desktop
-      - install -D io.defn.Franz.appdata.xml /app/share/appdata/io.defn.Franz.appdata.xml
-    build-options:
-      no-debuginfo: true
+      - install -D icon.svg -t /app/share/icons/hicolor/scalable/apps/
+      - install -D io.defn.Franz.desktop -t /app/share/applications/
+      - install -D io.defn.Franz.metainfo.xml -t /app/share/metainfo/
     sources:
       - type: archive
-        url: 'https://franz.defn.io/releases/Franz 1.6.0002.linux.x86_64.tar.gz'
-        sha256: 2e8e6307c1ba0f3b2c0c300bc123a06403fcf1639c2bf6e46b02b414dd407edd
+        url: https://franz.defn.io/releases/Franz%20Latest.linux.x86_64.tar.gz
+        sha256: 71a459d24dee787c2c8b57af3d1dc9b6f61bdc956487224cc8d6a4e1370b3807
         strip-components: 0
+      - type: file
+        path: io.defn.Franz.metainfo.xml
+      - type: file
+        path: io.defn.Franz.desktop


### PR DESCRIPTION
- Update the runtime version to 25.08
- Update Franz version to 1.9.
- Simplify the install commands
- Provide the desktop and metainfo files. Upstream does not provide them.
- Comply with Flathub styling guidelines

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide